### PR TITLE
Datei in Lektion 3 besser findbar machen

### DIFF
--- a/basics/input.tex
+++ b/basics/input.tex
@@ -26,7 +26,7 @@ Nun aber direkt zur Praxis:
 
 \textbf{Praxis:}
 \begin{enumerate}
-    \item Öffnet die Datei \texttt{vorkurs/lektion3/helloyou.cpp} in eurem Texteditor
+    \item Öffnet die Datei \texttt{vorkurs/lektion03/helloyou.cpp} in eurem Texteditor
     \item Öffnet ein Terminal und wechselt in das Verzeichnis \texttt{vorkurs/lektion3}
     \item Kompiliert im Terminal die Datei (\texttt{g++ -o helloyou
         helloyou.cpp}) und führt sie aus (\texttt{./helloyou})


### PR DESCRIPTION
Statt dem üblichen Verzeichnis "lektion03" war hier "lektion3"
angegeben. fixes #36