### PR TITLE
Praxis-Nummerierung Lektion 16 vereinheitlichen

### DIFF
--- a/basics/warning.tex
+++ b/basics/warning.tex
@@ -70,7 +70,7 @@ Terminal geschlossen habt, neu ausführen, denn er geht bei Schließung eines
 Terminals verloren!
 
 \textbf{Praxis:}
-\begin{enumerate}
+\begin{enumerate}[resume]
     \item Mit der warning in \texttt{warnings.cpp} möchte euch der Compiler
         darauf hinweisen, dass ihr hier eine Zuweisung macht, obwohl ein
         Wahrheitswert erwartet wird. Es gibt zwei Möglichkeiten, die warning zu


### PR DESCRIPTION
Es gibt hier 3 Praxis-Teile, von denen der zweite die Nummerierung neu
begonnen hat. Das hat zu Verwirrung geführt. Jetzt sollte den Leuten
klar werden, dass das ein aufgeteilter Praxis-Teil ist.
fixes #40