### PR TITLE
Anwendungsmenu in Anwendungen umbenennen

### DIFF
--- a/basics/hello_world.tex
+++ b/basics/hello_world.tex
@@ -71,8 +71,8 @@ Diagramm:
 
 \textbf{Praxis:}
 \begin{enumerate}
-	\item Öffnet ein Terminal, ihr findet dies im Anwendungsmenü unter
-		„Systemwerkzeuge“
+	\item Öffnet ein Terminal, ihr findet dies in den Anwendungen (oben rechts)
+		unter „Systemwerkzeuge“
     \item Wechselt in das Verzeichnis \texttt{vorkurs/lektion01}, indem ihr
 		\texttt{cd vorkurs/lektion01}\footnote{was dieser Befehl genau tut und wie er funktioniert, erfahrt ihr in Lektion 2} eingebt und enter drückt.
     \item In diesem Verzeichnis liegt eine Datei \texttt{helloworld.cpp}.
@@ -86,7 +86,7 @@ Diagramm:
 \textbf{Spiel:}
 
 Ihr könnt nun versuchen, den Quellcode selbst zu verändern und damit ein wenig
-herumzuspielen. Öffnet dazu einen Editor (im Anwendungsmenü findet ihr z.B.
+herumzuspielen. Öffnet dazu einen Editor (in den Anwendungen findet ihr z.B.
 unter „Zubehör“ den Editor gedit) und öffnet die Datei
 \texttt{vorkurs/lektion01/helloworld.cpp}\footnote{entweder mittels
 "Datei/Öffnen" in gedit oder über das Terminal mittels \texttt{gedit

--- a/basics/konsole.tex
+++ b/basics/konsole.tex
@@ -10,7 +10,7 @@ Mittel der Wahl, wenn man sich mit dem System auseinander setzen, oder auch
 allgemein arbeiten will. Wir erachten zumindest die Shell als wichtig genug, um
 euch direkt zu beginn damit zu konfrontieren.
 
-Wann immer ihr über das Anwendungsmenü ein Terminal startet, wird dort drin
+Wann immer ihr über die Anwendungen ein Terminal startet, wird dort drin
 automatisch auch eine shell gestartet. Die beiden Konzepte sind tatsächlich so
 eng miteinander verknüpft, dass ihr euch um die Unterschiede erst einmal keine
 Gedanken machen müsst - wann immer ihr Shell oder Terminal hört, denkt einfach


### PR DESCRIPTION
Das Anwendungsmenu auf den aktuellen Rechnern heißt nur noch
"Anwendungen". Das wird hiermit klar.
fixes #32